### PR TITLE
When created Message object I check, when text is null  - 'alert' key is...

### DIFF
--- a/src/Mcfedr/AwsPushBundle/Message/Message.php
+++ b/src/Mcfedr/AwsPushBundle/Message/Message.php
@@ -301,12 +301,9 @@ class Message implements \JsonSerializable
      */
     private function getApnsJson($text)
     {
-        $apns = [
-            'aps' => [
-                'alert' => $text
-            ]
-        ];
-        if ($this->badge) {
+        $apns = $text ? ['aps' => ['alert' => $text]] : ['aps' => []];
+
+        if (!is_null($this->badge)) {
             $apns['aps']['badge'] = $this->badge;
         }
         if ($this->sound) {


### PR DESCRIPTION
... removed from 'aps' structure