### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/src/Mcfedr/AwsPushBundle/Message/Message.php
+++ b/src/Mcfedr/AwsPushBundle/Message/Message.php
@@ -679,7 +679,7 @@ class Message implements \JsonSerializable
         return $this;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $data = [
             'default' => $this->text,


### PR DESCRIPTION
Fixes PHP 8.1 deprecation:
```
Deprecated: Return type of Mcfedr\AwsPushBundle\Message\Message::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/mcfedr/awspushbundle/src/Mcfedr/AwsPushBundle/Message/Message.php on line 682
```