### PR TITLE
Review custom exception handling with JsonSerializable

### DIFF
--- a/src/Mcfedr/AwsPushBundle/Service/Messages.php
+++ b/src/Mcfedr/AwsPushBundle/Service/Messages.php
@@ -92,30 +92,13 @@ class Messages
         $this->sns->publish(
             [
                 'TargetArn' => $endpointArn,
-                'Message' => $this->encodeMessage($message),
+                'Message' => json_encode($message, JSON_UNESCAPED_UNICODE),
                 'MessageStructure' => 'json',
                 'MessageAttributes' => [
                     'AWS.SNS.MOBILE.APNS.PUSH_TYPE' => ['DataType' => 'String', 'StringValue' => $message->getPushType()],
                 ],
             ]
         );
-    }
-
-    /**
-     * @throws MessageTooLongException
-     */
-    private function encodeMessage(Message $message): string
-    {
-        try {
-            $json = json_encode($message, JSON_UNESCAPED_UNICODE);
-
-            return $json;
-        } catch (\Exception $e) {
-            if ($e->getPrevious() instanceof MessageTooLongException) {
-                throw $e->getPrevious();
-            }
-            throw $e;
-        }
     }
 
     /**

--- a/tests/Mcfedr/AwsPushBundle/Tests/Message/MessageTest.php
+++ b/tests/Mcfedr/AwsPushBundle/Tests/Message/MessageTest.php
@@ -20,14 +20,7 @@ class MessageTest extends TestCase
         $this->expectException(MessageTooLongException::class);
         $message->setAllowTrimming(false);
 
-        try {
-            echo json_encode($message);
-        } catch (\Exception $e) {
-            if ($e->getPrevious() instanceof MessageTooLongException) {
-                throw $e->getPrevious();
-            }
-            throw $e;
-        }
+        json_encode($message);
     }
 
     /**


### PR DESCRIPTION
Since PHP version 5.6.27, 7.0.33, custom exceptions thrown in in `jsonSerialize` method are not wrapped anymore inside an `Exception` with a previous exception.

See https://3v4l.org/j88AN for the test suite.