### PR TITLE
Fix test deprecation warning

### DIFF
--- a/src/Mcfedr/AwsPushBundle/Message/Message.php
+++ b/src/Mcfedr/AwsPushBundle/Message/Message.php
@@ -700,6 +700,9 @@ class Message implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * @return array
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {


### PR DESCRIPTION
This will fix this deprecation report warning:

```
1x: Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Mcfedr\AwsPushBundle\Message\Message" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in ApiControllerTest::testRegisterDevice from Mcfedr\AwsPushBundle\Tests\Controller
```