### PR TITLE
add apns-collapse-id for Apple devices

### DIFF
--- a/src/Mcfedr/AwsPushBundle/Message/Message.php
+++ b/src/Mcfedr/AwsPushBundle/Message/Message.php
@@ -264,7 +264,8 @@ class Message implements \JsonSerializable
     private $gcmData;
 
     /**
-     * GCM, FCM and ADM only.
+     * The collapseKey will be sent for GCM, FCM and ADM
+     * and if set, apns-collapse-id is sent for APNS.
      *
      * @var string
      */

--- a/src/Mcfedr/AwsPushBundle/Service/Messages.php
+++ b/src/Mcfedr/AwsPushBundle/Service/Messages.php
@@ -89,14 +89,20 @@ class Messages
             $message->setPlatforms($this->platforms);
         }
 
+        $messageAttributes = [
+            'AWS.SNS.MOBILE.APNS.PUSH_TYPE' => ['DataType' => 'String', 'StringValue' => $message->getPushType()],
+        ];
+
+        if ($message->getCollapseKey() != Message::NO_COLLAPSE) {
+            $messageAttributes['AWS.SNS.MOBILE.APNS.COLLAPSE_ID'] = ['DataType' => 'String', 'StringValue' => $message->getCollapseKey()];
+        }
+
         $this->sns->publish(
             [
                 'TargetArn' => $endpointArn,
                 'Message' => json_encode($message, JSON_UNESCAPED_UNICODE),
                 'MessageStructure' => 'json',
-                'MessageAttributes' => [
-                    'AWS.SNS.MOBILE.APNS.PUSH_TYPE' => ['DataType' => 'String', 'StringValue' => $message->getPushType()],
-                ],
+                'MessageAttributes' => $messageAttributes,
             ]
         );
     }

--- a/tests/Mcfedr/AwsPushBundle/Tests/Service/MessagesTest.php
+++ b/tests/Mcfedr/AwsPushBundle/Tests/Service/MessagesTest.php
@@ -179,4 +179,42 @@ class MessagesTest extends TestCase
         $messages->send($message, 'arn');
     }
 
+    public function testSendWithCollapseKey()
+    {
+        $messages = new Messages($this->client, []);
+
+        $collapseKey = uniqid();
+
+        $this->client
+            ->expects($this->once())
+            ->method('publish')
+            ->with([
+                'TargetArn' => 'arn',
+                'Message' => '"data"',
+                'MessageStructure' => 'json',
+                'MessageAttributes' => [
+                    'AWS.SNS.MOBILE.APNS.PUSH_TYPE' => ['DataType' => 'String', 'StringValue' => 'alert'],
+                    'AWS.SNS.MOBILE.APNS.COLLAPSE_ID' => ['DataType' => 'String', 'StringValue' => $collapseKey],
+                ],
+            ]);
+
+        $message = $this->getMockBuilder(Message::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $message->expects($this->any())
+            ->method('getCollapseKey')
+            ->willReturn($collapseKey);
+
+        $message->expects($this->once())
+            ->method('jsonSerialize')
+            ->willReturn('data');
+
+        $message->expects($this->once())
+            ->method('getPushType')
+            ->willReturn('alert');
+
+        $messages->send($message, 'arn');
+    }
+
 }

--- a/tests/Mcfedr/AwsPushBundle/Tests/Service/MessagesTest.php
+++ b/tests/Mcfedr/AwsPushBundle/Tests/Service/MessagesTest.php
@@ -49,6 +49,10 @@ class MessagesTest extends TestCase
             ->willReturn('data');
 
         $message->expects($this->once())
+            ->method('getCollapseKey')
+            ->willReturn(Message::NO_COLLAPSE);
+
+        $message->expects($this->once())
             ->method('getPushType')
             ->willReturn('alert');
 
@@ -82,6 +86,10 @@ class MessagesTest extends TestCase
         $message->expects($this->once())
             ->method('isPlatformsCustomized')
             ->willReturn(false);
+
+        $message->expects($this->once())
+            ->method('getCollapseKey')
+            ->willReturn(Message::NO_COLLAPSE);
 
         $message->expects($this->once())
             ->method('getPushType')
@@ -123,6 +131,10 @@ class MessagesTest extends TestCase
             ->willReturn(true);
 
         $message->expects($this->once())
+            ->method('getCollapseKey')
+            ->willReturn(Message::NO_COLLAPSE);
+
+        $message->expects($this->once())
             ->method('getPushType')
             ->willReturn('alert');
 
@@ -157,9 +169,14 @@ class MessagesTest extends TestCase
             ->willReturn('data');
 
         $message->expects($this->once())
+            ->method('getCollapseKey')
+            ->willReturn(Message::NO_COLLAPSE);
+
+        $message->expects($this->once())
             ->method('getPushType')
             ->willReturn('background');
 
         $messages->send($message, 'arn');
     }
+
 }


### PR DESCRIPTION
add apns-collapse-id for Apple devices, collapse_key is supported only for Android devices